### PR TITLE
added _WD_DebugSwitch()

### DIFF
--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -1720,6 +1720,38 @@ Func _WD_GetWebDriverVersion($sInstallDir, $sDriverEXE)
 EndFunc   ;==>_WD_GetWebDriverVersion
 
 ; #FUNCTION# ====================================================================================================================
+; Name ..........: _WD_DebugSwitch
+; Description ...: Switch to new debug level or switch back to saved debug level
+; Syntax ........: _WD_DebugSwitch([$vMode = Default])
+; Parameters ....: $vMode               - [optional] Set new $_WD_DEBUG level. When not specified restore saved debug level.
+; Return values .: None
+; Author ........: mLipok
+; Modified ......:
+; Remarks .......: Function saves debug level at first call, or when Null is passed as $vMode
+; Related .......:
+; Link ..........:
+; Example .......: _WD_DebugSwitch($_WD_DEBUG_Full)
+; ===============================================================================================================================
+Func _WD_DebugSwitch($vMode = Default)
+	Local Const $sFuncName = "_WD_DebugSwitch"
+	Local Static $_WD_DEBUG_Saved = $_WD_DEBUG ; at first run save currently used debug level, and treat them as "DEFAULT USER CHOICE"
+	Local $iErr = $_WD_ERROR_Success
+
+	If $vMode = Default Then ; restore saved debug level
+		$_WD_DEBUG = $_WD_DEBUG_Saved
+	ElseIf $vMode = Null Then ; reset saved debug level
+		$_WD_DEBUG_Saved = $_WD_DEBUG
+	ElseIf Not IsInt($vMode) Then
+		$iErr = $_WD_ERROR_InvalidDataType
+	ElseIf $vMode < $_WD_DEBUG_None Or $vMode > $_WD_DEBUG_Full Then
+		$iErr = $_WD_ERROR_InvalidValue
+	Else ; set new debug level
+		$_WD_DEBUG = $vMode
+	EndIf
+	Return SetError(__WD_Error($sFuncName, $iErr), 0, '')
+EndFunc   ;==>_WD_DebugSwitch
+
+; #FUNCTION# ====================================================================================================================
 ; Name ..........: _WD_DownloadFile
 ; Description ...: Download file and save to disk.
 ; Syntax ........: _WD_DownloadFile($sURL, $sDest[, $iOptions = Default])


### PR DESCRIPTION
## Pull request

### Proposed changes

This PR adds function `_WD_DebugSwitch()` which give a way to switch and switch back between $_WD_DEBUG levels.

### Checklist

Put an `x` in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We are here to help!<br>
This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

Please check `x` the type of change your PR introduces:

- [ ] Bugfix (change which fixes an issue)
- [x] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?

When you want to switch to `$_WD_DEBUG_Full` and then back then you must rember what level was set previously.

### What is the new behavior?

this following example shows new behavior:
```autoit
_MAIN()

Func _Main()
	; presetting
	$_WD_DEBUG = $_WD_DEBUG_None
	
	_1()
	
	; restore settings ($_WD_DEBUG_None)
	_WD_DebugSwitch()


	; set new debug level
	$_WD_DEBUG = $_WD_DEBUG_Error
	; reset switch internall storage to new setting ($_WD_DEBUG_Error)
	_WD_DebugSwitch(Null)
	
EndFunc

Func _1()
	; first usage - internally store current settings + switch to $_WD_DEBUG_Full
	_WD_DebugSwitch($_WD_DEBUG_Full)
	; do your stuff
	_2()
	; do your stuff
EndFunc

Func _2()
	; switch to $_WD_DEBUG_Error
	_WD_DebugSwitch($_WD_DEBUG_Error)
	; do your stuff
EndFunc

```

### Additional context

https://www.autoitscript.com/forum/topic/205553-webdriver-udf-help-support-iii/?do=findComment&comment=1504312

### System under test

not related
